### PR TITLE
ACTIN-2466: Improve filtering of NCR records in NCR ingestion

### DIFF
--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/NcrFunctions.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/NcrFunctions.kt
@@ -7,6 +7,11 @@ import kotlin.math.max
 const val DIAGNOSIS_EPISODE = "DIA"
 const val FOLLOW_UP_EPISODE = "VERB"
 
+const val METASTATIC_DETECTION_ABSENT = 0
+const val METASTATIC_DETECTION_AT_START = 1
+const val METASTATIC_DETECTION_AT_PROGRESSION = 2
+
+
 object NcrFunctions {
 
     fun diagnosisRecord(records: List<NcrRecord>): NcrRecord {
@@ -14,7 +19,8 @@ object NcrFunctions {
     }
 
     fun metastaticRecord(records: List<NcrRecord>): NcrRecord {
-        return records.single { it.identification.metaEpis == 1 || it.identification.metaEpis == 2 }
+        return records.single { it.identification.metaEpis == METASTATIC_DETECTION_AT_START || 
+                it.identification.metaEpis == METASTATIC_DETECTION_AT_PROGRESSION }
     }
 
     fun recordsWithMinDaysSinceDiagnosis(records: List<NcrRecord>): Map<NcrRecord, Int> {

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/NcrFunctions.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/NcrFunctions.kt
@@ -5,12 +5,11 @@ import com.hartwig.actin.personalization.ncr.interpretation.conversion.Metastati
 import kotlin.math.max
 
 const val DIAGNOSIS_EPISODE = "DIA"
-const val FOLLOW_UP_EPISODE = "VERB"
+const val FOLLOWUP_EPISODE = "VERB"
 
 const val METASTATIC_DETECTION_ABSENT = 0
 const val METASTATIC_DETECTION_AT_START = 1
 const val METASTATIC_DETECTION_AT_PROGRESSION = 2
-
 
 object NcrFunctions {
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
@@ -5,6 +5,30 @@ import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
 import com.hartwig.actin.personalization.ncr.interpretation.FOLLOW_UP_EPISODE
 
 class ComorbidityRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
+
+    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
+        return hasValidComorbidityData(tumorRecords)
+    }
+
+    internal fun hasValidComorbidityData(tumorRecords: List<NcrRecord>): Boolean {
+        val hasValidComorbidityData = tumorRecords.all {
+            it.comorbidities.allFieldsAreNull() ||
+                    (it.identification.epis != FOLLOW_UP_EPISODE && it.comorbidities.allFieldsAreNotNull())
+        }
+        if (!hasValidComorbidityData) {
+            log("Tumor ${tumorRecords.tumorId()} has comorbidity on follow-up episode")
+        }
+        return hasValidComorbidityData
+    }
+
+    private fun NcrCharlsonComorbidities.allFieldsAreNull(): Boolean {
+        return allFields().all { it == null }
+    }
+
+    private fun NcrCharlsonComorbidities.allFieldsAreNotNull(): Boolean {
+        return allFields().all { it != null }
+    }
+
     private fun NcrCharlsonComorbidities.allFields(): List<Any?> {
         return listOf(
             cci,
@@ -27,26 +51,5 @@ class ComorbidityRecordFilter(override val logFilteredRecords: Boolean) : Record
             cciSevereLiver,
             cciUlcer
         )
-    }
-    
-    private fun NcrCharlsonComorbidities.allFieldsAreNull(): Boolean {
-        return allFields().all { it == null }
-    }
-    
-    private fun NcrCharlsonComorbidities.allFieldsAreNotNull(): Boolean {
-        return allFields().all { it != null }
-    }
-
-    internal fun hasValidComorbidityData(tumorRecords: List<NcrRecord>): Boolean {
-        val hasValidComorbidityData = tumorRecords.all { it.comorbidities.allFieldsAreNull() || (it.identification.epis != FOLLOW_UP_EPISODE && it.comorbidities.allFieldsAreNotNull()) }
-        if (!hasValidComorbidityData) {
-            log("Tumor ${tumorRecords.tumorId()} has comorbidity on follow-up episode")
-        }
-        return hasValidComorbidityData
-    }
-
-
-    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
-        return hasValidComorbidityData(tumorRecords)
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
@@ -12,7 +12,7 @@ class ComorbidityRecordFilter(override val logFilteredRecords: Boolean) : Record
 
     internal fun hasValidComorbidityData(tumorRecords: List<NcrRecord>): Boolean {
         val hasValidComorbidityData = tumorRecords.all {
-            (it.identification.epis == FOLLOWUP_EPISODE && it.comorbidities.allFieldsAreNull()) ||
+            it.comorbidities.allFieldsAreNull() ||
                     (it.identification.epis != FOLLOWUP_EPISODE && it.comorbidities.allFieldsAreNotNull())
         }
         

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilter.kt
@@ -2,7 +2,7 @@ package com.hartwig.actin.personalization.ncr.interpretation.filter
 
 import com.hartwig.actin.personalization.ncr.datamodel.NcrCharlsonComorbidities
 import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
-import com.hartwig.actin.personalization.ncr.interpretation.FOLLOW_UP_EPISODE
+import com.hartwig.actin.personalization.ncr.interpretation.FOLLOWUP_EPISODE
 
 class ComorbidityRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
@@ -12,12 +12,14 @@ class ComorbidityRecordFilter(override val logFilteredRecords: Boolean) : Record
 
     internal fun hasValidComorbidityData(tumorRecords: List<NcrRecord>): Boolean {
         val hasValidComorbidityData = tumorRecords.all {
-            it.comorbidities.allFieldsAreNull() ||
-                    (it.identification.epis != FOLLOW_UP_EPISODE && it.comorbidities.allFieldsAreNotNull())
+            (it.identification.epis == FOLLOWUP_EPISODE && it.comorbidities.allFieldsAreNull()) ||
+                    (it.identification.epis != FOLLOWUP_EPISODE && it.comorbidities.allFieldsAreNotNull())
         }
+        
         if (!hasValidComorbidityData) {
             log("Tumor ${tumorRecords.tumorId()} has comorbidity on follow-up episode")
         }
+        
         return hasValidComorbidityData
     }
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
@@ -9,23 +9,12 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
-            ::hasAtLeastOneMetastaticDetection,
             ::hasAtMostOneMetastaticDetection,
             ::hasEmptyMetastaticFieldIfDetectionNotPresent,
             ::hasConsistentMetastaticProgression,
         ).all { it(tumorRecords) }
     }
     
-    internal fun hasAtLeastOneMetastaticDetection(records: List<NcrRecord>): Boolean {
-        val hasAtLeastOneClinicalMetastaticDetection = records.any { it.primaryDiagnosis.cm != null && it.primaryDiagnosis.cm != "0" }
-        val hasAtLeastOnePathologicalMetastaticDetection = records.any { it.primaryDiagnosis.pm != null && it.primaryDiagnosis.pm != "-" }
-        val hasAtLeastOneMetastaticDetection = hasAtLeastOneClinicalMetastaticDetection || hasAtLeastOnePathologicalMetastaticDetection
-        if (!hasAtLeastOneMetastaticDetection) {
-            log("No metastatic detection found in tumor ${records.tumorId()}")
-        }
-        return hasAtLeastOneMetastaticDetection
-    }
-
     internal fun hasAtMostOneMetastaticDetection(records: List<NcrRecord>): Boolean {
         val metastaticRecords = records.filter {
             it.identification.metaEpis == METASTATIC_DETECTION_AT_START ||

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
@@ -64,7 +64,7 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
                 )
             }
             if (record.identification.metaEpis == METASTATIC_DETECTION_AT_START) {
-                allMetaProgression.all { !it.notZeroNorNull() }
+                allMetaProgression.any { it.zeroOrNull() }
             } else {
                 allMetaProgression.any { it.notZeroNorNull() }
             }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
@@ -7,6 +7,16 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
     private val METASTATIC_DETECTION_AT_START = 1
     private val METASTATIC_DETECTION_AT_PROGRESSION = 2
 
+    internal fun hasAtLeastOneMetastaticDetection(records: List<NcrRecord>): Boolean {
+        val hasAtLeastOneClinicalMetastaticDetection = records.any { it.primaryDiagnosis.cm != null && it.primaryDiagnosis.cm != "0" }
+        val hasAtLeastOnePathologicalMetastaticDetection = records.any { it.primaryDiagnosis.pm != null && it.primaryDiagnosis.pm != "-" }
+        val hasAtLeastOneMetastaticDetection = hasAtLeastOneClinicalMetastaticDetection || hasAtLeastOnePathologicalMetastaticDetection
+        if (!hasAtLeastOneMetastaticDetection) {
+            log("No metastatic detection found in tumor ${records.tumorId()}")
+        }
+        return hasAtLeastOneMetastaticDetection
+    }
+    
     internal fun hasAtMostOneMetastaticDetection(records: List<NcrRecord>): Boolean {
         val metastaticRecords =
             records.filter { it.identification.metaEpis == METASTATIC_DETECTION_AT_START || it.identification.metaEpis == METASTATIC_DETECTION_AT_PROGRESSION }
@@ -71,6 +81,7 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
             ::hasAtMostOneMetastaticDetection,
             ::hasEmptyMetastaticFieldIfDetectionNotPresent,
             ::hasConsistentMetastaticProgression,
+            ::hasAtLeastOneMetastaticDetection,
         ).all { it(tumorRecords) }
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilter.kt
@@ -9,21 +9,23 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
-            ::hasAtMostOneMetastaticDetection,
+            ::hasAtMostOneMetastaticRecord,
             ::hasEmptyMetastaticFieldIfDetectionNotPresent,
             ::hasConsistentMetastaticProgression,
         ).all { it(tumorRecords) }
     }
     
-    internal fun hasAtMostOneMetastaticDetection(records: List<NcrRecord>): Boolean {
+    internal fun hasAtMostOneMetastaticRecord(records: List<NcrRecord>): Boolean {
         val metastaticRecords = records.filter {
             it.identification.metaEpis == METASTATIC_DETECTION_AT_START ||
                     it.identification.metaEpis == METASTATIC_DETECTION_AT_PROGRESSION
         }
         val hasAtMostOneMetastaticDetection = metastaticRecords.size <= 1
+        
         if (!hasAtMostOneMetastaticDetection) {
-            log("Multiple metastatic detections found in tumor ${records.tumorId()}")
+            log("Multiple metastatic records found in tumor ${records.tumorId()}")
         }
+        
         return hasAtMostOneMetastaticDetection
     }
 
@@ -45,9 +47,11 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
                     record.treatment.metastaticRadiotherapy.metaRtCode4 == null
             hasEmptyMetastaticDiagnosis && hasEmptyMetastaticSurgery && hasEmptyMetastaticRadiotherapy
         }
+        
         if (!hasEmptyMetastaticFieldIfDetectionNotPresent) {
             log("Non-empty metastatic fields found in tumor ${records.tumorId()} without detection")
         }
+        
         return hasEmptyMetastaticFieldIfDetectionNotPresent
     }
 
@@ -73,6 +77,7 @@ class MetastaticDiagnosisRecordFilter(override val logFilteredRecords: Boolean) 
         if (!hasConsistentMetastaticProgression) {
             log("Inconsistent metastatic progression data found in tumor ${records.tumorId()}")
         }
+        
         return hasConsistentMetastaticProgression
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilter.kt
@@ -5,17 +5,19 @@ import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
 class MolecularRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
-        return hasNoMolecularDataForFollowUp(tumorRecords)
+        return hasNoMolecularDataForFollowup(tumorRecords)
     }
 
-    internal fun hasNoMolecularDataForFollowUp(tumorRecords: List<NcrRecord>): Boolean {
+    internal fun hasNoMolecularDataForFollowup(tumorRecords: List<NcrRecord>): Boolean {
         val (_, followupRecords) = splitDiagnosisAndFollowup(tumorRecords)
         val hasNoMolecularDataForFollowup = followupRecords.all { followup ->
             with(followup.molecularCharacteristics) { listOf(brafMut, rasMut, msiStat).all { it.zeroOrNull() } }
         }
+        
         if (!hasNoMolecularDataForFollowup) {
             log("Followup diagnosis contains molecular data for tumor ID: ${tumorRecords.tumorId()}")
         }
+        
         return hasNoMolecularDataForFollowup
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilter.kt
@@ -4,18 +4,18 @@ import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
 
 class MolecularRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
-    internal fun hasNoMolecularDataForFollowUp(tumorRecords: List<NcrRecord>): Boolean {
-        val (_, followUpDiagnosis) = extractPrimaryDiagnosis(tumorRecords)
-        val hasNoMolecularDataForFollowUp = followUpDiagnosis.all { followUp ->
-            with(followUp.molecularCharacteristics) { listOf(brafMut, rasMut, msiStat).all { it.ZeroOrNull() } }
-        }
-        if (!hasNoMolecularDataForFollowUp) {
-            log("Follow-up diagnosis contains molecular data for tumor ID: ${tumorRecords.tumorId()}")
-        }
-        return hasNoMolecularDataForFollowUp
-    }
-
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return hasNoMolecularDataForFollowUp(tumorRecords)
+    }
+
+    internal fun hasNoMolecularDataForFollowUp(tumorRecords: List<NcrRecord>): Boolean {
+        val (_, followupRecords) = splitDiagnosisAndFollowup(tumorRecords)
+        val hasNoMolecularDataForFollowup = followupRecords.all { followup ->
+            with(followup.molecularCharacteristics) { listOf(brafMut, rasMut, msiStat).all { it.zeroOrNull() } }
+        }
+        if (!hasNoMolecularDataForFollowup) {
+            log("Followup diagnosis contains molecular data for tumor ID: ${tumorRecords.tumorId()}")
+        }
+        return hasNoMolecularDataForFollowup
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
@@ -2,21 +2,21 @@ package com.hartwig.actin.personalization.ncr.interpretation.filter
 
 import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
 import com.hartwig.actin.personalization.ncr.interpretation.DIAGNOSIS_EPISODE
-import com.hartwig.actin.personalization.ncr.interpretation.FOLLOW_UP_EPISODE
+import com.hartwig.actin.personalization.ncr.interpretation.FOLLOWUP_EPISODE
 
 class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
-            ::hasValidTreatmentData,
+            ::hasConsistentTreatmentData,
             ::hasConsistentSex,
             ::hasExactlyOneDiagnosis,
-            ::hasVitalStatusForDiaRecords,
+            ::hasVitalStatusForDiagnosisRecords,
             ::hasEmptyVitalStatusForVerbRecords,
         ).all { it(tumorRecords) }
     }
-    
-    internal fun hasValidTreatmentData(tumorRecords: List<NcrRecord>): Boolean {
+
+    internal fun hasConsistentTreatmentData(tumorRecords: List<NcrRecord>): Boolean {
         val allTreatments = tumorRecords.map { it.treatment }
         val indicatesTreatmentButNoTreatmentDefined = allTreatments.any { treatment ->
             treatment.tumgerichtTher == 1 &&
@@ -32,8 +32,9 @@ class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilt
         }
 
         if (indicatesTreatmentButNoTreatmentDefined) {
-            log("Invalid treatment data found for set of NCR tumor records with ID: ${tumorRecords.tumorId()}")
+            log("Inconsistent treatment data found for set of NCR tumor records with ID: ${tumorRecords.tumorId()}")
         }
+
         return !indicatesTreatmentButNoTreatmentDefined
     }
 
@@ -55,25 +56,29 @@ class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilt
         return exactlyOneDiagnosis
     }
 
-    internal fun hasVitalStatusForDiaRecords(tumorRecords: List<NcrRecord>): Boolean {
+    internal fun hasVitalStatusForDiagnosisRecords(tumorRecords: List<NcrRecord>): Boolean {
         val diagnosisRecords = tumorRecords.filter { it.identification.epis == DIAGNOSIS_EPISODE }
 
         val hasVitalStatus =
             diagnosisRecords.all { it.patientCharacteristics.vitStat != null && it.patientCharacteristics.vitStatInt != null }
+
         if (!hasVitalStatus) {
             log("Missing vital status for diagnosis records of tumor ID ${tumorRecords.tumorId()}")
         }
+
         return hasVitalStatus
     }
 
     internal fun hasEmptyVitalStatusForVerbRecords(tumorRecords: List<NcrRecord>): Boolean {
-        val verbRecords = tumorRecords.filter { it.identification.epis == FOLLOW_UP_EPISODE }
+        val verbRecords = tumorRecords.filter { it.identification.epis == FOLLOWUP_EPISODE }
 
         val hasEmptyVitalStatus =
             verbRecords.all { it.patientCharacteristics.vitStat == null && it.patientCharacteristics.vitStatInt == null }
+        
         if (!hasEmptyVitalStatus) {
             log("Non-empty vital status found for verb records of tumor ID ${tumorRecords.tumorId()}")
         }
+        
         return hasEmptyVitalStatus
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
@@ -5,6 +5,17 @@ import com.hartwig.actin.personalization.ncr.interpretation.DIAGNOSIS_EPISODE
 import com.hartwig.actin.personalization.ncr.interpretation.FOLLOW_UP_EPISODE
 
 class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
+
+    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
+        return listOf(
+            ::hasValidTreatmentData,
+            ::hasConsistentSex,
+            ::hasExactlyOneDiagnosis,
+            ::hasVitalStatusForDiaRecords,
+            ::hasEmptyVitalStatusForVerbRecords,
+        ).all { it(tumorRecords) }
+    }
+    
     internal fun hasValidTreatmentData(tumorRecords: List<NcrRecord>): Boolean {
         val allTreatments = tumorRecords.map { it.treatment }
         val indicatesTreatmentButNoTreatmentDefined = allTreatments.any { treatment ->
@@ -64,15 +75,5 @@ class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilt
             log("Non-empty vital status found for verb records of tumor ID ${tumorRecords.tumorId()}")
         }
         return hasEmptyVitalStatus
-    }
-
-    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
-        return listOf(
-            ::hasValidTreatmentData,
-            ::hasConsistentSex,
-            ::hasExactlyOneDiagnosis,
-            ::hasVitalStatusForDiaRecords,
-            ::hasEmptyVitalStatusForVerbRecords,
-        ).all { it(tumorRecords) }
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilter.kt
@@ -66,16 +66,6 @@ class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilt
         return hasEmptyVitalStatus
     }
 
-    internal fun hasConsistentYearOfIncidence(tumorRecords: List<NcrRecord>): Boolean {
-        val uniqueYearsOfIncidence = tumorRecords.map { it.primaryDiagnosis.incjr }.toSet().size
-        val consistentYearOfIncidence = uniqueYearsOfIncidence == 1
-
-        if (!consistentYearOfIncidence) {
-            log("Multiple years of incidence found for tumor ID ${tumorRecords.tumorId()}")
-        }
-        return consistentYearOfIncidence
-    }
-
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
             ::hasValidTreatmentData,
@@ -83,7 +73,6 @@ class PatientRecordFilter(override val logFilteredRecords: Boolean) : RecordFilt
             ::hasExactlyOneDiagnosis,
             ::hasVitalStatusForDiaRecords,
             ::hasEmptyVitalStatusForVerbRecords,
-            ::hasConsistentYearOfIncidence
         ).all { it(tumorRecords) }
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -17,7 +17,7 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
         val hasValidDoubleTumorData = primaryDiagnosis.all { it.clinicalCharacteristics.dubbeltum != null } &&
                 followUpDiagnosis.all { it.clinicalCharacteristics.dubbeltum == 0 }
         if (!hasValidDoubleTumorData) {
-            log("Tumor ${tumorRecords.tumorId()} has invalid double tumor data")
+            log("Invalid double tumor data found for tumor ${tumorRecords.tumorId()}")
         }
         return hasValidDoubleTumorData
     }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -47,8 +47,8 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
             ::hasValidDoubleTumorData,
-            ::hasValidMorfCatData,
-            ::hasValidAnusAfstData,
+//            ::hasValidMorfCatData,
+//            ::hasValidAnusAfstData,
             ::hasConsistentTopoSublokData
         ).all { it(tumorRecords) }
     }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -13,12 +13,14 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
     }
 
     internal fun hasValidDoubleTumorData(tumorRecords: List<NcrRecord>): Boolean {
-        val (primaryDiagnosis, followUpDiagnosis) = splitDiagnosisAndFollowup(tumorRecords)
-        val hasValidDoubleTumorData = primaryDiagnosis.all { it.clinicalCharacteristics.dubbeltum != null } &&
-                followUpDiagnosis.all { it.clinicalCharacteristics.dubbeltum == 0 }
+        val (diagnosis, followup) = splitDiagnosisAndFollowup(tumorRecords)
+        val hasValidDoubleTumorData = diagnosis.all { it.clinicalCharacteristics.dubbeltum != null } &&
+                followup.all { it.clinicalCharacteristics.dubbeltum == 0 }
+        
         if (!hasValidDoubleTumorData) {
             log("Invalid double tumor data found for tumor ${tumorRecords.tumorId()}")
         }
+        
         return hasValidDoubleTumorData
     }
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -47,8 +47,8 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
             ::hasValidDoubleTumorData,
-//            ::hasValidMorfCatData,
-//            ::hasValidAnusAfstData,
+            ::hasValidMorfCatData,
+            ::hasValidAnusAfstData,
             ::hasConsistentTopoSublokData
         ).all { it(tumorRecords) }
     }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -8,8 +8,7 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
         return listOf(
             ::hasValidDoubleTumorData,
             ::hasValidMorfCatData,
-            ::hasValidAnusAfstData,
-            ::hasConsistentTopoSublokData
+            ::hasValidAnusAfstData
         ).all { it(tumorRecords) }
     }
 
@@ -44,14 +43,5 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
         }
         
         return hasValidAnusAfstData
-    }
-
-    internal fun hasConsistentTopoSublokData(tumorRecords: List<NcrRecord>): Boolean {
-        val allTopoSubLock = tumorRecords.map { it.primaryDiagnosis.topoSublok }
-        val hasConsistentTopoSublokData = allTopoSubLock.toSet().size == 1
-        if (!hasConsistentTopoSublokData) {
-            log("Tumor ${tumorRecords.tumorId()} has inconsistent topoSublok data: $allTopoSubLock")
-        }
-        return hasConsistentTopoSublokData
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilter.kt
@@ -14,26 +14,6 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
         return hasValidDoubleTumorData
     }
 
-
-    internal fun hasValidMorfCatData(tumorRecords: List<NcrRecord>): Boolean {
-        val (primaryDiagnosis,followUpDiagnosis) = extractPrimaryDiagnosis(tumorRecords)
-        val hasValidMorfCatData = primaryDiagnosis.all { it.primaryDiagnosis.morfCat != null } &&
-               followUpDiagnosis.all { it.primaryDiagnosis.morfCat == null }
-        if (!hasValidMorfCatData) {
-            log("Tumor ${tumorRecords.tumorId()} has invalid morfCat data")
-        }
-        return hasValidMorfCatData
-    }
-
-    internal fun hasValidAnusAfstData(tumorRecords: List<NcrRecord>): Boolean {
-        val (primaryDiagnosis,followUpDiagnosis) = extractPrimaryDiagnosis(tumorRecords)
-        val hasValidAnusAfstData = primaryDiagnosis.all { it.clinicalCharacteristics.anusAfst != null } &&
-               followUpDiagnosis.all { it.clinicalCharacteristics.anusAfst == null }
-        if (!hasValidAnusAfstData) {
-            log("Tumor ${tumorRecords.tumorId()} has invalid anusAfst data")
-        }
-        return hasValidAnusAfstData
-    }
     
     internal fun hasConsistentTopoSublokData(tumorRecords: List<NcrRecord>): Boolean {
         val allTopoSubLock = tumorRecords.map { it.primaryDiagnosis.topoSublok }
@@ -47,8 +27,6 @@ class PrimaryTumorRecordFilter(override val logFilteredRecords: Boolean) : Recor
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
             ::hasValidDoubleTumorData,
-            ::hasValidMorfCatData,
-            ::hasValidAnusAfstData,
             ::hasConsistentTopoSublokData
         ).all { it(tumorRecords) }
     }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilter.kt
@@ -6,12 +6,14 @@ import kotlin.reflect.full.memberProperties
 
 class PriorTumorRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
-    inline fun <reified T : Any> allFieldsAreNull(obj: T): Boolean {
-        return T::class.memberProperties.all { prop ->
-            prop.get(obj) == null
-        }
+    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
+        return listOf(
+            ::hasEmptyPriorTumorInVerbEpisode,
+            ::hasNoPositiveValueInMalInt,
+            ::hasCompletePriorTumorData
+        ).all { it(tumorRecords) }
     }
-
+    
     internal fun hasEmptyPriorTumorInVerbEpisode(tumorRecords: List<NcrRecord>): Boolean {
         val verbRecords = tumorRecords.filter { it.identification.epis == FOLLOW_UP_EPISODE }
 
@@ -56,11 +58,9 @@ class PriorTumorRecordFilter(override val logFilteredRecords: Boolean) : RecordF
         return allNullOrComplete
     }
 
-    override fun apply(tumorRecords: List<NcrRecord>): Boolean {
-        return listOf(
-            ::hasEmptyPriorTumorInVerbEpisode,
-            ::hasNoPositiveValueInMalInt,
-            ::hasCompletePriorTumorData
-        ).all { it(tumorRecords) }
+    private inline fun <reified T : Any> allFieldsAreNull(obj: T): Boolean {
+        return T::class.memberProperties.all { prop ->
+            prop.get(obj) == null
+        }
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilter.kt
@@ -1,26 +1,28 @@
 package com.hartwig.actin.personalization.ncr.interpretation.filter
 
 import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
-import com.hartwig.actin.personalization.ncr.interpretation.FOLLOW_UP_EPISODE
+import com.hartwig.actin.personalization.ncr.interpretation.FOLLOWUP_EPISODE
 import kotlin.reflect.full.memberProperties
 
 class PriorTumorRecordFilter(override val logFilteredRecords: Boolean) : RecordFilter {
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
-            ::hasEmptyPriorTumorInVerbEpisode,
+            ::hasEmptyPriorTumorInFollowups,
             ::hasNoPositiveValueInMalInt,
             ::hasCompletePriorTumorData
         ).all { it(tumorRecords) }
     }
     
-    internal fun hasEmptyPriorTumorInVerbEpisode(tumorRecords: List<NcrRecord>): Boolean {
-        val verbRecords = tumorRecords.filter { it.identification.epis == FOLLOW_UP_EPISODE }
+    internal fun hasEmptyPriorTumorInFollowups(tumorRecords: List<NcrRecord>): Boolean {
+        val followups = tumorRecords.filter { it.identification.epis == FOLLOWUP_EPISODE }
 
-        val hasEmptyPriorTumor = verbRecords.all { allFieldsAreNull(it.priorMalignancies) }
+        val hasEmptyPriorTumor = followups.all { allFieldsAreNull(it.priorMalignancies) }
+        
         if (!hasEmptyPriorTumor) {
             log("Non-empty prior tumor data found for verb records of tumor ID ${tumorRecords.tumorId()}")
         }
+        
         return hasEmptyPriorTumor
     }
 
@@ -34,15 +36,17 @@ class PriorTumorRecordFilter(override val logFilteredRecords: Boolean) : RecordF
             )
         }.filterNotNull()
         val hasNoPositiveValues = allMalIntValues.all { it <= 0 }
+        
         if (!hasNoPositiveValues) {
             log("Found positive malInt values for tumor ID ${tumorRecords.tumorId()}: $allMalIntValues")
         }
+        
         return hasNoPositiveValues
     }
 
     internal fun hasCompletePriorTumorData(tumorRecords: List<NcrRecord>): Boolean {
-        val allPriorTumorInfo = tumorRecords.map { it -> it.priorMalignancies }
-            .flatMap { it ->
+        val allPriorTumorInfo = tumorRecords.map { it.priorMalignancies }
+            .flatMap {
                 listOf(
                     listOf(it.mal1Int, it.mal1Morf, it.mal1TopoSublok, it.mal1Tumsoort, it.mal1Syst),
                     listOf(it.mal2Int, it.mal2Morf, it.mal2TopoSublok, it.mal2Tumsoort, it.mal2Syst),
@@ -52,9 +56,11 @@ class PriorTumorRecordFilter(override val logFilteredRecords: Boolean) : RecordF
             }
         val allNullOrComplete =
             allPriorTumorInfo.all { priorMalignancy -> priorMalignancy.all { it == null } || priorMalignancy.none { it == null } }
+        
         if (!allNullOrComplete) {
             log("Incomplete prior tumor data found for tumor ID ${tumorRecords.tumorId()}: $allPriorTumorInfo")
         }
+        
         return allNullOrComplete
     }
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
@@ -20,7 +20,7 @@ interface RecordFilter {
 
 internal fun List<NcrRecord>.tumorId() = first().identification.keyZid
 
-internal fun extractPrimaryDiagnosis(records: List<NcrRecord>): Pair<List<NcrRecord>, List<NcrRecord>> {
+internal fun splitDiagnosisAndFollowup(records: List<NcrRecord>): Pair<List<NcrRecord>, List<NcrRecord>> {
     return records.partition { it.identification.epis == DIAGNOSIS_EPISODE }
 }
 
@@ -28,6 +28,6 @@ internal fun Int?.notZeroNorNull(): Boolean {
     return this != null && this != 0
 }
 
-internal fun Int?.ZeroOrNull(): Boolean {
+internal fun Int?.zeroOrNull(): Boolean {
     return this == null || this == 0
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
@@ -6,11 +6,12 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 
 interface RecordFilter {
     val logFilteredRecords: Boolean
+    
     private val logger get() = KotlinLogging.logger {}
 
     fun log(message: String) {
         if (logFilteredRecords) {
-            logger.info { message }
+            logger.warn { message }
         }
     }
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/RecordFilter.kt
@@ -15,7 +15,6 @@ interface RecordFilter {
         }
     }
 
-
     fun apply(tumorRecords: List<NcrRecord>): Boolean
 }
 

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
@@ -1,6 +1,7 @@
 package com.hartwig.actin.personalization.ncr.interpretation.filter
 
 import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
+import com.hartwig.actin.personalization.ncr.datamodel.NcrTreatment
 
 private const val PRE_SURGERY_CODE = 1
 private const val POST_SURGERY_CODE = 2
@@ -9,6 +10,7 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
+            ::hasConsistentReasonRefrainingTreatment,
             ::hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy,
             ::hasValidPrimarySurgery,
             ::hasValidPrimaryRadiotherapy,
@@ -17,7 +19,43 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             ::hasValidSystemCodes
         ).all { it(tumorRecords) }
     }
-    
+
+    internal fun hasConsistentReasonRefrainingTreatment(tumorRecords: List<NcrRecord>): Boolean {
+        val allRecordsHaveNoTreatment = tumorRecords.map { it.treatment }.all { treatment ->
+            !hasAtLeastOneTreatment(treatment)
+        }
+
+        val allRecordsMissReasonForRefrainment = tumorRecords.map { it.treatment }.all { treatment ->
+            treatment.geenTherReden == null
+        }
+        
+        val hasConsistentReasonRefraining = !(allRecordsHaveNoTreatment && allRecordsMissReasonForRefrainment)
+        if (!hasConsistentReasonRefraining) log("Inconsistent reason for refraining treatment for tumor ${tumorRecords.tumorId()}")
+        
+        return hasConsistentReasonRefraining
+    }
+
+    private fun hasAtLeastOneTreatment(treatment: NcrTreatment): Boolean {
+        return listOf(
+            treatment.gastroenterologyResection.mdlRes,
+            treatment.primarySurgery.chir,
+            treatment.primaryRadiotherapy.rt,
+            treatment.primaryRadiotherapy.chemort,
+            treatment.systemicTreatment.chemo,
+            treatment.systemicTreatment.target,
+            treatment.hipec.hipec
+        ).any { it.notZeroNorNull() } ||
+                listOf(
+                    treatment.metastaticSurgery.metaChirCode1,
+                    treatment.metastaticSurgery.metaChirCode2,
+                    treatment.metastaticSurgery.metaChirCode3,
+                    treatment.metastaticRadiotherapy.metaRtCode1,
+                    treatment.metastaticRadiotherapy.metaRtCode2,
+                    treatment.metastaticRadiotherapy.metaRtCode3,
+                    treatment.metastaticRadiotherapy.metaRtCode4,
+                ).any { it != null }
+    }
+
     private fun hasConsistentPreAndPostSurgicalIntervals(
         surgeryChir: Int?,
         surgeryStartInt: Int?,
@@ -51,11 +89,11 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
                             it.primaryRadiotherapy.rtStartInt1
                         )
             }
-        
+
         if (!hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy) {
             log("Invalid therapy pre/post codes for tumor ${tumorRecords.tumorId()}")
         }
-        
+
         return hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy
     }
 
@@ -66,9 +104,9 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             val hasPrimarySurgeryType2 = treatment.primarySurgery.chirType2.notZeroNorNull()
             hasPrimarySurgeryChir == (hasPrimarySurgeryType1 || hasPrimarySurgeryType2)
         }
-        
+
         if (!hasValidPrimarySurgery) log("Primary surgery validity check failed for tumor ${tumorRecords.tumorId()}")
-        
+
         return hasValidPrimarySurgery
     }
 
@@ -80,9 +118,9 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             val hasPrimaryRadiotherapyType2 = treatment.primaryRadiotherapy.rtType2.notZeroNorNull()
             (hasPrimaryRadiotherapyRt || hasPrimaryRadiotherapyChemort) == (hasPrimaryRadiotherapyType1 || hasPrimaryRadiotherapyType2)
         }
-        
+
         if (!hasValidPrimaryRadiotherapy) log("Primary radiotherapy validity check failed for tumor ${tumorRecords.tumorId()}")
-        
+
         return hasValidPrimaryRadiotherapy
     }
 
@@ -93,9 +131,9 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             val hasGastroResectionType2 = treatment.gastroenterologyResection.mdlResType2.notZeroNorNull()
             hasGastroResection == (hasGastroResectionType1 || hasGastroResectionType2)
         }
-        
+
         if (!hasValidGastroResection) log("Gastrointestinal resection validity check failed for tumor ${tumorRecords.tumorId()}")
-        
+
         return hasValidGastroResection
     }
 
@@ -121,11 +159,11 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             ).any { code -> code != null }
             hasSystemicCode == (hasSystemicChemo || hasSystemicTarget)
         }
-        
+
         if (!hasValidSystemicTreatment) {
             log("Systemic treatment validation failed: chemo, target, or codes are inconsistent for tumor ${tumorRecords.tumorId()}")
         }
-        
+
         return hasValidSystemicTreatment
     }
 
@@ -151,9 +189,9 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
                 code != null || schemaNum == null
             }
         }
-        
+
         if (!hasValidSystemCodes) log("Systemic codes validation failed: found schemaNum without code for tumor ${tumorRecords.tumorId()}")
-        
+
         return hasValidSystemCodes
     }
 }

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
@@ -1,7 +1,6 @@
 package com.hartwig.actin.personalization.ncr.interpretation.filter
 
 import com.hartwig.actin.personalization.ncr.datamodel.NcrRecord
-import com.hartwig.actin.personalization.ncr.datamodel.NcrTreatment
 
 private const val PRE_SURGERY_CODE = 1
 private const val POST_SURGERY_CODE = 2
@@ -10,7 +9,6 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
 
     override fun apply(tumorRecords: List<NcrRecord>): Boolean {
         return listOf(
-            ::hasConsistentReasonRefrainingTreatment,
             ::hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy,
             ::hasValidPrimarySurgery,
             ::hasValidPrimaryRadiotherapy,
@@ -18,42 +16,6 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
             ::hasValidSystemicTreatment,
             ::hasValidSystemCodes
         ).all { it(tumorRecords) }
-    }
-
-    internal fun hasConsistentReasonRefrainingTreatment(tumorRecords: List<NcrRecord>): Boolean {
-        val allRecordsHaveNoTreatment = tumorRecords.map { it.treatment }.all { treatment ->
-            !hasAtLeastOneTreatment(treatment)
-        }
-
-        val allRecordsMissReasonForRefrainment = tumorRecords.map { it.treatment }.all { treatment ->
-            treatment.geenTherReden == null
-        }
-        
-        val hasConsistentReasonRefraining = !(allRecordsHaveNoTreatment && allRecordsMissReasonForRefrainment)
-        if (!hasConsistentReasonRefraining) log("Inconsistent reason for refraining treatment for tumor ${tumorRecords.tumorId()}")
-        
-        return hasConsistentReasonRefraining
-    }
-
-    private fun hasAtLeastOneTreatment(treatment: NcrTreatment): Boolean {
-        return listOf(
-            treatment.gastroenterologyResection.mdlRes,
-            treatment.primarySurgery.chir,
-            treatment.primaryRadiotherapy.rt,
-            treatment.primaryRadiotherapy.chemort,
-            treatment.systemicTreatment.chemo,
-            treatment.systemicTreatment.target,
-            treatment.hipec.hipec
-        ).any { it.notZeroNorNull() } ||
-                listOf(
-                    treatment.metastaticSurgery.metaChirCode1,
-                    treatment.metastaticSurgery.metaChirCode2,
-                    treatment.metastaticSurgery.metaChirCode3,
-                    treatment.metastaticRadiotherapy.metaRtCode1,
-                    treatment.metastaticRadiotherapy.metaRtCode2,
-                    treatment.metastaticRadiotherapy.metaRtCode3,
-                    treatment.metastaticRadiotherapy.metaRtCode4,
-                ).any { it != null }
     }
 
     private fun hasConsistentPreAndPostSurgicalIntervals(

--- a/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
+++ b/ncr/src/main/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilter.kt
@@ -18,6 +18,29 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
         ).all { it(tumorRecords) }
     }
 
+    internal fun hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy(tumorRecords: List<NcrRecord>): Boolean {
+        val hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy =
+            tumorRecords.map { it.treatment }.all {
+                hasConsistentPreAndPostSurgicalIntervals(
+                    it.primarySurgery.chir,
+                    it.primarySurgery.chirInt1,
+                    it.primaryRadiotherapy.rt,
+                    it.primaryRadiotherapy.rtStartInt1
+                ) && hasConsistentPreAndPostSurgicalIntervals(
+                    it.primarySurgery.chir,
+                    it.primarySurgery.chirInt1,
+                    it.primaryRadiotherapy.chemort,
+                    it.primaryRadiotherapy.rtStartInt1
+                )
+            }
+
+        if (!hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy) {
+            log("Invalid therapy pre/post codes for tumor ${tumorRecords.tumorId()}")
+        }
+
+        return hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy
+    }
+
     private fun hasConsistentPreAndPostSurgicalIntervals(
         surgeryChir: Int?,
         surgeryStartInt: Int?,
@@ -33,30 +56,6 @@ class TreatmentRecordFilter(override val logFilteredRecords: Boolean) : RecordFi
 
             else -> true
         }
-    }
-
-    internal fun hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy(tumorRecords: List<NcrRecord>): Boolean {
-        val hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy =
-            tumorRecords.map { it.treatment }.all { it ->
-                hasConsistentPreAndPostSurgicalIntervals(
-                    it.primarySurgery.chir,
-                    it.primarySurgery.chirInt1,
-                    it.primaryRadiotherapy.rt,
-                    it.primaryRadiotherapy.rtStartInt1
-                ) &&
-                        hasConsistentPreAndPostSurgicalIntervals(
-                            it.primarySurgery.chir,
-                            it.primarySurgery.chirInt1,
-                            it.primaryRadiotherapy.chemort,
-                            it.primaryRadiotherapy.rtStartInt1
-                        )
-            }
-
-        if (!hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy) {
-            log("Invalid therapy pre/post codes for tumor ${tumorRecords.tumorId()}")
-        }
-
-        return hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy
     }
 
     internal fun hasValidPrimarySurgery(tumorRecords: List<NcrRecord>): Boolean {

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/datamodel/TestNcrRecordFactory.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/datamodel/TestNcrRecordFactory.kt
@@ -263,7 +263,7 @@ object TestNcrRecordFactory {
             diffgrad = 2,
             ct = "0",
             cn = null,
-            cm = "1",
+            cm = null,
             pt = null,
             pn = null,
             pm = null,

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/datamodel/TestNcrRecordFactory.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/datamodel/TestNcrRecordFactory.kt
@@ -263,7 +263,7 @@ object TestNcrRecordFactory {
             diffgrad = 2,
             ct = "0",
             cn = null,
-            cm = null,
+            cm = "1",
             pt = null,
             pn = null,
             pm = null,

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/ComorbidityRecordFilterTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ComorbidityRecordFilterTest {
+
     private val filter = ComorbidityRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
     private val minimalFollowupRecord = TestNcrRecordFactory.minimalFollowupRecord()

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
@@ -5,22 +5,27 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class MetastaticDiagnosisRecordFilterTest {
+
     private val filter = MetastaticDiagnosisRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
-    
+
     @Test
     fun `Should return true for zero metastatic episodes`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0)
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0)
+            )
+        )
         assertThat(filter.hasAtMostOneMetastaticDetection(records)).isTrue()
     }
-    
+
     @Test
     fun `Should return true for one metastatic detection`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)
+            )
+        )
         assertThat(filter.hasAtMostOneMetastaticDetection(records)).isTrue()
     }
 
@@ -35,79 +40,122 @@ class MetastaticDiagnosisRecordFilterTest {
 
     @Test
     fun `Should return true when metastatic fields are empty if detection not present`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0),
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0),
+            )
+        )
         assertThat(filter.hasEmptyMetastaticFieldIfDetectionNotPresent(records)).isTrue()
     }
 
     @Test
     fun `Should return false when metastatic fields are not empty if detection not present`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0),
-            metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(metaProg1 = 1),
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                metastaticSurgery = minimalDiagnosisRecord.treatment.metastaticSurgery.copy(metaChirCode1 = "surgery"),
-                metastaticRadiotherapy = minimalDiagnosisRecord.treatment.metastaticRadiotherapy.copy(metaRtCode1 = "radiotherapy")
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0),
+                metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(metaProg1 = 1),
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    metastaticSurgery = minimalDiagnosisRecord.treatment.metastaticSurgery.copy(metaChirCode1 = "surgery"),
+                    metastaticRadiotherapy = minimalDiagnosisRecord.treatment.metastaticRadiotherapy.copy(metaRtCode1 = "radiotherapy")
+                )
             )
-        ))
+        )
         assertThat(filter.hasEmptyMetastaticFieldIfDetectionNotPresent(records)).isFalse()
     }
 
     @Test
     fun `Should return true for consistent progression`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1),
-            metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
-                metaProg1 = 0, metaProg2 = 0, metaProg3 = 0, metaProg4 = 0, metaProg5 = 0, metaProg6 = 0, metaProg7 = 0, metaProg8 = 0, metaProg9 = 0, metaProg10 = 0
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1),
+                metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
+                    metaProg1 = 0,
+                    metaProg2 = 0,
+                    metaProg3 = 0,
+                    metaProg4 = 0,
+                    metaProg5 = 0,
+                    metaProg6 = 0,
+                    metaProg7 = 0,
+                    metaProg8 = 0,
+                    metaProg9 = 0,
+                    metaProg10 = 0
+                )
             )
-        ))
+        )
         assertThat(filter.hasConsistentMetastaticProgression(records)).isTrue()
     }
 
     @Test
     fun `Should return false for inconsistent progression with at_progression`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),
-            metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
-                metaProg1 = 0, metaProg2 = 0, metaProg3 = 0, metaProg4 = 0, metaProg5 = 0, metaProg6 = 0, metaProg7 = 0, metaProg8 = 0, metaProg9 = 0, metaProg10 = 0
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),
+                metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
+                    metaProg1 = 0,
+                    metaProg2 = 0,
+                    metaProg3 = 0,
+                    metaProg4 = 0,
+                    metaProg5 = 0,
+                    metaProg6 = 0,
+                    metaProg7 = 0,
+                    metaProg8 = 0,
+                    metaProg9 = 0,
+                    metaProg10 = 0
+                )
             )
-        ))
+        )
         assertThat(filter.hasConsistentMetastaticProgression(records)).isFalse()
     }
-    
+
     @Test
     fun `Should return true for inconsistent progression with at_progression`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),
-            metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
-                metaProg1 = 1, metaProg2 = 0, metaProg3 = 0, metaProg4 = 0, metaProg5 = 0, metaProg6 = 0, metaProg7 = 0, metaProg8 = 0, metaProg9 = 0, metaProg10 = 0
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),
+                metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
+                    metaProg1 = 1,
+                    metaProg2 = 0,
+                    metaProg3 = 0,
+                    metaProg4 = 0,
+                    metaProg5 = 0,
+                    metaProg6 = 0,
+                    metaProg7 = 0,
+                    metaProg8 = 0,
+                    metaProg9 = 0,
+                    metaProg10 = 0
+                )
             )
-        ))
+        )
         assertThat(filter.hasConsistentMetastaticProgression(records)).isTrue()
     }
 
     @Test
     fun `Should return true when at least one clinical metastatic detection is present`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "1", pm = "-")
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "1", pm = "-")
+            )
+        )
         assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
     }
 
     @Test
     fun `Should return true when at least one pathological metastatic detection is present`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "A")
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "A")
+            )
+        )
         assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
     }
 
     @Test
     fun `Should return false when no clinical or pathological metastatic detection is present`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "-")
-        ))
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "-")
+            )
+        )
         assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isFalse()
     }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
@@ -10,7 +10,7 @@ class MetastaticDiagnosisRecordFilterTest {
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
 
     @Test
-    fun `Should return true for zero metastatic episodes`() {
+    fun `Should return true for zero metastatic records`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0)
@@ -20,7 +20,7 @@ class MetastaticDiagnosisRecordFilterTest {
     }
 
     @Test
-    fun `Should return true for one metastatic detection`() {
+    fun `Should return true for one record with metastatic detection`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)
@@ -30,7 +30,7 @@ class MetastaticDiagnosisRecordFilterTest {
     }
 
     @Test
-    fun `Should return false for more than one metastatic detection`() {
+    fun `Should return false for more than one record with metastatic detection`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)),
             minimalDiagnosisRecord.copy(identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2))
@@ -64,21 +64,13 @@ class MetastaticDiagnosisRecordFilterTest {
     }
 
     @Test
-    fun `Should return true for consistent progression`() {
+    fun `Should return true for at least one metastases without progression in case of detection at start`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1),
                 metastaticDiagnosis = minimalDiagnosisRecord.metastaticDiagnosis.copy(
                     metaProg1 = 0,
-                    metaProg2 = 0,
-                    metaProg3 = 0,
-                    metaProg4 = 0,
-                    metaProg5 = 0,
-                    metaProg6 = 0,
-                    metaProg7 = 0,
-                    metaProg8 = 0,
-                    metaProg9 = 0,
-                    metaProg10 = 0
+                    metaProg2 = 1
                 )
             )
         )
@@ -86,7 +78,7 @@ class MetastaticDiagnosisRecordFilterTest {
     }
 
     @Test
-    fun `Should return false for inconsistent progression with at_progression`() {
+    fun `Should return false for having no progression metastases in an episode with metastases during progression`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),
@@ -108,7 +100,7 @@ class MetastaticDiagnosisRecordFilterTest {
     }
 
     @Test
-    fun `Should return true for inconsistent progression with at_progression`() {
+    fun `Should return true for consistent progression in an episode with metastases at progression`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2),

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
@@ -128,34 +128,4 @@ class MetastaticDiagnosisRecordFilterTest {
         )
         assertThat(filter.hasConsistentMetastaticProgression(records)).isTrue()
     }
-
-    @Test
-    fun `Should return true when at least one clinical metastatic detection is present`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(
-                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "1", pm = "-")
-            )
-        )
-        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return true when at least one pathological metastatic detection is present`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(
-                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "A")
-            )
-        )
-        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false when no clinical or pathological metastatic detection is present`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(
-                primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "-")
-            )
-        )
-        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isFalse()
-    }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
@@ -16,7 +16,7 @@ class MetastaticDiagnosisRecordFilterTest {
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 0)
             )
         )
-        assertThat(filter.hasAtMostOneMetastaticDetection(records)).isTrue()
+        assertThat(filter.hasAtMostOneMetastaticRecord(records)).isTrue()
     }
 
     @Test
@@ -26,7 +26,7 @@ class MetastaticDiagnosisRecordFilterTest {
                 identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)
             )
         )
-        assertThat(filter.hasAtMostOneMetastaticDetection(records)).isTrue()
+        assertThat(filter.hasAtMostOneMetastaticRecord(records)).isTrue()
     }
 
     @Test
@@ -35,7 +35,7 @@ class MetastaticDiagnosisRecordFilterTest {
             minimalDiagnosisRecord.copy(identification = minimalDiagnosisRecord.identification.copy(metaEpis = 1)),
             minimalDiagnosisRecord.copy(identification = minimalDiagnosisRecord.identification.copy(metaEpis = 2))
         )
-        assertThat(filter.hasAtMostOneMetastaticDetection(records)).isFalse()
+        assertThat(filter.hasAtMostOneMetastaticRecord(records)).isFalse()
     }
 
     @Test

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MetastaticDiagnosisRecordFilterTest.kt
@@ -86,4 +86,28 @@ class MetastaticDiagnosisRecordFilterTest {
         ))
         assertThat(filter.hasConsistentMetastaticProgression(records)).isTrue()
     }
+
+    @Test
+    fun `Should return true when at least one clinical metastatic detection is present`() {
+        val records = listOf(minimalDiagnosisRecord.copy(
+            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "1", pm = "-")
+        ))
+        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return true when at least one pathological metastatic detection is present`() {
+        val records = listOf(minimalDiagnosisRecord.copy(
+            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "A")
+        ))
+        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return false when no clinical or pathological metastatic detection is present`() {
+        val records = listOf(minimalDiagnosisRecord.copy(
+            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(cm = "0", pm = "-")
+        ))
+        assertThat(filter.hasAtLeastOneMetastaticDetection(records)).isFalse()
+    }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilterTest.kt
@@ -15,12 +15,12 @@ class MolecularRecordFilterTest {
                 brafMut = 1, rasMut = 1, msiStat = 1
             )
         ))
-        assertThat(filter.hasNoMolecularDataForFollowUp(records)).isFalse()
+        assertThat(filter.hasNoMolecularDataForFollowup(records)).isFalse()
     }
 
     @Test
     fun `Should return true for empty molecular data in followup`() {
         val records = listOf(TestNcrRecordFactory.minimalFollowupRecord())
-        assertThat(filter.hasNoMolecularDataForFollowUp(records)).isTrue()
+        assertThat(filter.hasNoMolecularDataForFollowup(records)).isTrue()
     }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/MolecularRecordFilterTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class MolecularRecordFilterTest {
+    
     private val filter = MolecularRecordFilter(true)
 
     @Test

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/NcrQualityFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/NcrQualityFilterTest.kt
@@ -35,7 +35,7 @@ class NcrQualityFilterTest {
                 record1Patient3
             )
         )
-        
+
         assertThat(filtered).containsExactly(record1Patient1, record2Patient1, record1Patient2)
     }
 
@@ -67,7 +67,11 @@ class NcrQualityFilterTest {
             treatment = noTreatmentButFlaggedAsHavingOne.treatment.copy(
                 tumgerichtTher = 1,
                 geenTherReden = null,
-                systemicTreatment = noTreatmentButFlaggedAsHavingOne.treatment.systemicTreatment.copy(target = 1, chemo = 1, systCode1 = "code1")
+                systemicTreatment = noTreatmentButFlaggedAsHavingOne.treatment.systemicTreatment.copy(
+                    target = 1,
+                    chemo = 1,
+                    systCode1 = "code1"
+                )
             )
         )
         assertThat(filter.run(listOf(recordWithValidTreatmentData))).containsExactly(recordWithValidTreatmentData)

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
@@ -122,36 +122,4 @@ class PatientRecordFilterTest {
         ))        
         assertThat(filter.hasEmptyVitalStatusForVerbRecords(records)).isFalse()
     }
-
-    @Test
-    fun `Should return true when all records have identical year of incidence`() {
-        val record1 = minimalDiagnosisRecord.copy(
-            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(
-                incjr = 2020
-            )
-        )
-        val record2 = TestNcrRecordFactory.minimalFollowupRecord().copy(
-            primaryDiagnosis = TestNcrRecordFactory.minimalFollowupRecord().primaryDiagnosis.copy(
-                incjr = 2020
-            )
-        )
-        val records = listOf(record1, record2)
-        assertThat(filter.hasConsistentYearOfIncidence(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false when records have different year of incidence`() {
-        val record1 = minimalDiagnosisRecord.copy(
-            primaryDiagnosis = minimalDiagnosisRecord.primaryDiagnosis.copy(
-                incjr = 2020
-            )
-        )
-        val record2 = TestNcrRecordFactory.minimalFollowupRecord().copy(
-            primaryDiagnosis = TestNcrRecordFactory.minimalFollowupRecord().primaryDiagnosis.copy(
-                incjr = 2021
-            )
-        )
-        val records = listOf(record1, record2)
-        assertThat(filter.hasConsistentYearOfIncidence(records)).isFalse()
-    }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
@@ -12,7 +12,7 @@ class PatientRecordFilterTest {
     @Test
     fun `Should return true when treatment is valid`() {
         val records = listOf(minimalDiagnosisRecord)
-        assertThat(filter.hasValidTreatmentData(records)).isTrue()
+        assertThat(filter.hasConsistentTreatmentData(records)).isTrue()
     }
 
     @Test
@@ -41,7 +41,7 @@ class PatientRecordFilterTest {
                 )
             )
         ))
-        assertThat(filter.hasValidTreatmentData(records)).isFalse()
+        assertThat(filter.hasConsistentTreatmentData(records)).isFalse()
     }
 
     @Test
@@ -88,7 +88,7 @@ class PatientRecordFilterTest {
                 vitStatInt = 1
             )
         ))
-        assertThat(filter.hasVitalStatusForDiaRecords(records)).isTrue()
+        assertThat(filter.hasVitalStatusForDiagnosisRecords(records)).isTrue()
     }
 
     @Test
@@ -99,7 +99,7 @@ class PatientRecordFilterTest {
                 vitStatInt = null
             )
         ))
-        assertThat(filter.hasVitalStatusForDiaRecords(records)).isFalse()
+        assertThat(filter.hasVitalStatusForDiagnosisRecords(records)).isFalse()
     }
 
     @Test

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PatientRecordFilterTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class PatientRecordFilterTest {
+    
     private val filter = PatientRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
 

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
@@ -49,58 +49,6 @@ class PrimaryTumorRecordFilterTest {
     }
 
     @Test
-    fun `Should return true for valid morfCat data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(morfCat = 1)
-            ),
-            followUpRecord.copy(
-                primaryDiagnosis = followUpRecord.primaryDiagnosis.copy(morfCat = null)
-            )
-        )
-        assertThat(filter.hasValidMorfCatData(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false for invalid morfCat data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(morfCat = null)
-            ),
-            followUpRecord.copy(
-                primaryDiagnosis = followUpRecord.primaryDiagnosis.copy(morfCat = 1)
-            )
-        )
-        assertThat(filter.hasValidMorfCatData(records)).isFalse()
-    }
-
-    @Test
-    fun `Should return true for valid anusAfst data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                clinicalCharacteristics = diagnosisRecord.clinicalCharacteristics.copy(anusAfst = 1)
-            ),
-            followUpRecord.copy(
-                clinicalCharacteristics = followUpRecord.clinicalCharacteristics.copy(anusAfst = null)
-            )
-        )
-        assertThat(filter.hasValidAnusAfstData(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false for invalid anusAfst data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                clinicalCharacteristics = diagnosisRecord.clinicalCharacteristics.copy(anusAfst = null)
-            ),
-            followUpRecord.copy(
-                clinicalCharacteristics = followUpRecord.clinicalCharacteristics.copy(anusAfst = 1)
-            )
-        )
-        assertThat(filter.hasValidAnusAfstData(records)).isFalse()
-    }
-
-    @Test
     fun `Should return true for consistent topoSublok data`() {
         val records = listOf(
             diagnosisRecord.copy(

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
@@ -8,7 +8,7 @@ class PrimaryTumorRecordFilterTest {
     
     private val filter = PrimaryTumorRecordFilter(true)
     private val diagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
-    private val followUpRecord = TestNcrRecordFactory.minimalFollowupRecord()
+    private val followupRecord = TestNcrRecordFactory.minimalFollowupRecord()
 
     @Test
     fun `Should return true for valid double tumor data`() {
@@ -16,8 +16,8 @@ class PrimaryTumorRecordFilterTest {
             diagnosisRecord.copy(
                 clinicalCharacteristics = diagnosisRecord.clinicalCharacteristics.copy(dubbeltum = 1)
             ),
-            followUpRecord.copy(
-                clinicalCharacteristics = followUpRecord.clinicalCharacteristics.copy(dubbeltum = 0)
+            followupRecord.copy(
+                clinicalCharacteristics = followupRecord.clinicalCharacteristics.copy(dubbeltum = 0)
             )
         )
         assertThat(filter.hasValidDoubleTumorData(records)).isTrue()
@@ -29,8 +29,8 @@ class PrimaryTumorRecordFilterTest {
             diagnosisRecord.copy(
                 clinicalCharacteristics = diagnosisRecord.clinicalCharacteristics.copy(dubbeltum = null)
             ),
-            followUpRecord.copy(
-                clinicalCharacteristics = followUpRecord.clinicalCharacteristics.copy(dubbeltum = null)
+            followupRecord.copy(
+                clinicalCharacteristics = followupRecord.clinicalCharacteristics.copy(dubbeltum = null)
             )
         )
         assertThat(filter.hasValidDoubleTumorData(records)).isFalse()
@@ -42,11 +42,59 @@ class PrimaryTumorRecordFilterTest {
             diagnosisRecord.copy(
                 clinicalCharacteristics = diagnosisRecord.clinicalCharacteristics.copy(dubbeltum = 1)
             ),
-            followUpRecord.copy(
-                clinicalCharacteristics = followUpRecord.clinicalCharacteristics.copy(dubbeltum = 1)
+            followupRecord.copy(
+                clinicalCharacteristics = followupRecord.clinicalCharacteristics.copy(dubbeltum = 1)
             )
         )
         assertThat(filter.hasValidDoubleTumorData(records)).isFalse()
+    }
+
+    @Test
+    fun `Should return true for valid morfCat data`() {
+        val records = listOf(
+            diagnosisRecord.copy(
+                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(morfCat = 1)
+            ),
+            followupRecord.copy(
+                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(morfCat = null)
+            )
+        )
+        assertThat(filter.hasValidMorfCatData(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return false for invalid morfCat data`() {
+        val records = listOf(
+            diagnosisRecord.copy(
+                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(morfCat = null)
+            ),
+            followupRecord.copy(
+                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(morfCat = 1)
+            )
+        )
+        assertThat(filter.hasValidMorfCatData(records)).isFalse()
+    }
+
+    @Test
+    fun `Should return true for valid anusAfst data`() {
+        val records = listOf(
+            diagnosisRecord,
+            followupRecord.copy(
+                clinicalCharacteristics = followupRecord.clinicalCharacteristics.copy(anusAfst = null)
+            )
+        )
+        assertThat(filter.hasValidAnusAfstData(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return false for invalid anusAfst data`() {
+        val records = listOf(
+            diagnosisRecord,
+            followupRecord.copy(
+                clinicalCharacteristics = followupRecord.clinicalCharacteristics.copy(anusAfst = 1)
+            )
+        )
+        assertThat(filter.hasValidAnusAfstData(records)).isFalse()
     }
 
     @Test
@@ -55,8 +103,8 @@ class PrimaryTumorRecordFilterTest {
             diagnosisRecord.copy(
                 primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(topoSublok = "C000")
             ),
-            followUpRecord.copy(
-                primaryDiagnosis = followUpRecord.primaryDiagnosis.copy(topoSublok = "C000")
+            followupRecord.copy(
+                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(topoSublok = "C000")
             )
         )
         assertThat(filter.hasConsistentTopoSublokData(records)).isTrue()
@@ -68,8 +116,8 @@ class PrimaryTumorRecordFilterTest {
             diagnosisRecord.copy(
                 primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(topoSublok = "C000")
             ),
-            followUpRecord.copy(
-                primaryDiagnosis = followUpRecord.primaryDiagnosis.copy(topoSublok = "C001")
+            followupRecord.copy(
+                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(topoSublok = "C001")
             )
         )
         assertThat(filter.hasConsistentTopoSublokData(records)).isFalse()

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class PrimaryTumorRecordFilterTest {
+    
     private val filter = PrimaryTumorRecordFilter(true)
     private val diagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
     private val followUpRecord = TestNcrRecordFactory.minimalFollowupRecord()

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PrimaryTumorRecordFilterTest.kt
@@ -96,30 +96,4 @@ class PrimaryTumorRecordFilterTest {
         )
         assertThat(filter.hasValidAnusAfstData(records)).isFalse()
     }
-
-    @Test
-    fun `Should return true for consistent topoSublok data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(topoSublok = "C000")
-            ),
-            followupRecord.copy(
-                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(topoSublok = "C000")
-            )
-        )
-        assertThat(filter.hasConsistentTopoSublokData(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false for inconsistent topoSublok data`() {
-        val records = listOf(
-            diagnosisRecord.copy(
-                primaryDiagnosis = diagnosisRecord.primaryDiagnosis.copy(topoSublok = "C000")
-            ),
-            followupRecord.copy(
-                primaryDiagnosis = followupRecord.primaryDiagnosis.copy(topoSublok = "C001")
-            )
-        )
-        assertThat(filter.hasConsistentTopoSublokData(records)).isFalse()
-    }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilterTest.kt
@@ -13,7 +13,7 @@ class PriorTumorRecordFilterTest {
     @Test
     fun `Should return true when all VERB records have empty prior tumor data`() {
         val records = listOf(minimalFollowupRecord)
-        assertThat(filter.hasEmptyPriorTumorInVerbEpisode(records)).isTrue()
+        assertThat(filter.hasEmptyPriorTumorInFollowups(records)).isTrue()
     }
 
     @Test
@@ -23,7 +23,7 @@ class PriorTumorRecordFilterTest {
                 priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(mal1Int = 1)
             )
         )
-        assertThat(filter.hasEmptyPriorTumorInVerbEpisode(records)).isFalse()
+        assertThat(filter.hasEmptyPriorTumorInFollowups(records)).isFalse()
     }
 
     @Test

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/PriorTumorRecordFilterTest.kt
@@ -5,15 +5,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class PriorTumorRecordFilterTest {
+
     private val filter = PriorTumorRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
     private val minimalFollowupRecord = TestNcrRecordFactory.minimalFollowupRecord()
 
     @Test
     fun `Should return true when all VERB records have empty prior tumor data`() {
-        val records = listOf(
-          minimalFollowupRecord  
-        ) 
+        val records = listOf(minimalFollowupRecord)
         assertThat(filter.hasEmptyPriorTumorInVerbEpisode(records)).isTrue()
     }
 
@@ -21,51 +20,60 @@ class PriorTumorRecordFilterTest {
     fun `Should return false when any VERB record has non-empty prior tumor data`() {
         val records = listOf(
             minimalFollowupRecord.copy(
-            priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(mal1Int = 1)
-        ))
+                priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(mal1Int = 1)
+            )
+        )
         assertThat(filter.hasEmptyPriorTumorInVerbEpisode(records)).isFalse()
     }
 
     @Test
     fun `Should return true when all malInt values are non-positive`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
-                mal1Int = 0, mal2Int = -1, mal3Int = 0, mal4Int = null
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
+                    mal1Int = 0, mal2Int = -1, mal3Int = 0, mal4Int = null
+                )
             )
-        ))
+        )
         assertThat(filter.hasNoPositiveValueInMalInt(records)).isTrue()
     }
 
     @Test
     fun `Should return false when any malInt value is positive`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
-                mal1Int = 1, mal2Int = 0, mal3Int = null, mal4Int = null
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
+                    mal1Int = 1, mal2Int = 0, mal3Int = null, mal4Int = null
+                )
             )
-        ))
+        )
         assertThat(filter.hasNoPositiveValueInMalInt(records)).isFalse()
     }
 
     @Test
     fun `Should return true when all prior tumor data is complete or empty`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
-                mal1Int = null, mal1Morf = null, mal1TopoSublok = null, mal1Tumsoort = null, mal1Syst = null,
-                mal2Int = 0, mal2Morf = 0, mal2TopoSublok = "A", mal2Tumsoort = 0, mal2Syst = 0,
-                mal3Int = null, mal3Morf = null, mal3TopoSublok = null, mal3Tumsoort = null, mal3Syst = null,
-                mal4Int = 0, mal4Morf = 0, mal4TopoSublok = "B", mal4Tumsoort = 0, mal4Syst = 0
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
+                    mal1Int = null, mal1Morf = null, mal1TopoSublok = null, mal1Tumsoort = null, mal1Syst = null,
+                    mal2Int = 0, mal2Morf = 0, mal2TopoSublok = "A", mal2Tumsoort = 0, mal2Syst = 0,
+                    mal3Int = null, mal3Morf = null, mal3TopoSublok = null, mal3Tumsoort = null, mal3Syst = null,
+                    mal4Int = 0, mal4Morf = 0, mal4TopoSublok = "B", mal4Tumsoort = 0, mal4Syst = 0
+                )
             )
-        ))
+        )
         assertThat(filter.hasCompletePriorTumorData(records)).isTrue()
     }
 
     @Test
     fun `Should return false when any prior tumor data is partially filled`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
-                mal1Int = 1, mal1Morf = null, mal1TopoSublok = null, mal1Tumsoort = null, mal1Syst = null
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                priorMalignancies = minimalDiagnosisRecord.priorMalignancies.copy(
+                    mal1Int = 1, mal1Morf = null, mal1TopoSublok = null, mal1Tumsoort = null, mal1Syst = null
+                )
             )
-        ))
+        )
         assertThat(filter.hasCompletePriorTumorData(records)).isFalse()
     }
 }

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
@@ -7,29 +7,7 @@ import org.junit.jupiter.api.Test
 class TreatmentRecordFilterTest {
     private val filter = TreatmentRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
-
-    @Test
-    fun `Should return true for record with treatment and no reason`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
-                geenTherReden = null
-            )
-        ))
-        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false for record with treatment and reason`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
-                geenTherReden = 1
-            )
-        ))
-        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isFalse()
-    }
-
+    
     @Test
     fun `Should return true for valid intervals`() {
         val records = listOf(minimalDiagnosisRecord.copy(

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
@@ -10,41 +10,6 @@ class TreatmentRecordFilterTest {
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
     
     @Test
-    fun `Should return true for record with treatment and no reason`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(
-                treatment = minimalDiagnosisRecord.treatment.copy(
-                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
-                    geenTherReden = null
-                )
-            )
-        )
-        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return true for one record with treatment and another with reason`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(
-                treatment = minimalDiagnosisRecord.treatment.copy(
-                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
-                    geenTherReden = null
-                )
-            ),
-            minimalDiagnosisRecord.copy(treatment = minimalDiagnosisRecord.treatment.copy(geenTherReden = 1))
-        )
-        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isTrue()
-    }
-
-    @Test
-    fun `Should return false for no treatment and no reason refrainment`() {
-        val records = listOf(
-            minimalDiagnosisRecord.copy(treatment = minimalDiagnosisRecord.treatment.copy(geenTherReden = null))
-        )
-        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isFalse()
-    }
-
-    @Test
     fun `Should return true for valid intervals`() {
         val records = listOf(
             minimalDiagnosisRecord.copy(

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
@@ -8,6 +8,41 @@ class TreatmentRecordFilterTest {
 
     private val filter = TreatmentRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
+    
+    @Test
+    fun `Should return true for record with treatment and no reason`() {
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
+                    geenTherReden = null
+                )
+            )
+        )
+        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return true for one record with treatment and another with reason`() {
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1),
+                    geenTherReden = null
+                )
+            ),
+            minimalDiagnosisRecord.copy(treatment = minimalDiagnosisRecord.treatment.copy(geenTherReden = 1))
+        )
+        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isTrue()
+    }
+
+    @Test
+    fun `Should return false for no treatment and no reason refrainment`() {
+        val records = listOf(
+            minimalDiagnosisRecord.copy(treatment = minimalDiagnosisRecord.treatment.copy(geenTherReden = null))
+        )
+        assertThat(filter.hasConsistentReasonRefrainingTreatment(records)).isFalse()
+    }
 
     @Test
     fun `Should return true for valid intervals`() {

--- a/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
+++ b/ncr/src/test/kotlin/com/hartwig/actin/personalization/ncr/interpretation/filter/TreatmentRecordFilterTest.kt
@@ -5,130 +5,178 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class TreatmentRecordFilterTest {
+
     private val filter = TreatmentRecordFilter(true)
     private val minimalDiagnosisRecord = TestNcrRecordFactory.minimalDiagnosisRecord()
-    
+
     @Test
     fun `Should return true for valid intervals`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirInt1 = 10),
-                primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, rtStartInt1 = 5),
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, systStartInt1 = 5)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirInt1 = 10),
+                    primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, rtStartInt1 = 5),
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, systStartInt1 = 5)
+                )
             )
-        ))
+        )
         assertThat(filter.hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid intervals`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirInt1 = 5),
-                primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, rtStartInt1 = 10),
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, systStartInt1 = 10)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirInt1 = 5),
+                    primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, rtStartInt1 = 10),
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, systStartInt1 = 10)
+                )
             )
-        ))
+        )
         assertThat(filter.hasConsistentPreAndPostSurgicalIntervalsForChemoAndRadiotherapy(records)).isFalse()
     }
 
     @Test
     fun `Should return true for valid surgery data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirType1 = 1, chirType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirType1 = 1, chirType2 = null)
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidPrimarySurgery(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid surgery data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirType1 = null, chirType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primarySurgery = minimalDiagnosisRecord.treatment.primarySurgery.copy(chir = 1, chirType1 = null, chirType2 = null)
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidPrimarySurgery(records)).isFalse()
     }
 
     @Test
     fun `Should return true for valid radiotherapy data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, chemort = 0, rtType1 = 1, rtType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(
+                        rt = 1,
+                        chemort = 0,
+                        rtType1 = 1,
+                        rtType2 = null
+                    )
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidPrimaryRadiotherapy(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid radiotherapy data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(rt = 1, chemort = 0, rtType1 = null, rtType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    primaryRadiotherapy = minimalDiagnosisRecord.treatment.primaryRadiotherapy.copy(
+                        rt = 1,
+                        chemort = 0,
+                        rtType1 = null,
+                        rtType2 = null
+                    )
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidPrimaryRadiotherapy(records)).isFalse()
     }
 
     @Test
     fun `Should return true for valid gastro resection data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                gastroenterologyResection = minimalDiagnosisRecord.treatment.gastroenterologyResection.copy(mdlRes = 1, mdlResType1 = 1, mdlResType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    gastroenterologyResection = minimalDiagnosisRecord.treatment.gastroenterologyResection.copy(
+                        mdlRes = 1,
+                        mdlResType1 = 1,
+                        mdlResType2 = null
+                    )
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidGastroResection(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid gastro resection data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                gastroenterologyResection = minimalDiagnosisRecord.treatment.gastroenterologyResection.copy(mdlRes = 1, mdlResType1 = null, mdlResType2 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    gastroenterologyResection = minimalDiagnosisRecord.treatment.gastroenterologyResection.copy(
+                        mdlRes = 1,
+                        mdlResType1 = null,
+                        mdlResType2 = null
+                    )
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidGastroResection(records)).isFalse()
     }
 
     @Test
     fun `Should return true for valid systemic treatment data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, target = 1, systCode1 = "code1", systSchemanum1 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(
+                        chemo = 1,
+                        target = 1,
+                        systCode1 = "code1",
+                        systSchemanum1 = null
+                    )
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidSystemicTreatment(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid systemic treatment data`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, target = 0, systCode1 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(chemo = 1, target = 0, systCode1 = null)
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidSystemicTreatment(records)).isFalse()
     }
 
     @Test
     fun `Should return true for valid system codes`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(systCode1 = "code1", systSchemanum1 = null)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(systCode1 = "code1", systSchemanum1 = null)
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidSystemCodes(records)).isTrue()
     }
 
     @Test
     fun `Should return false for invalid system codes`() {
-        val records = listOf(minimalDiagnosisRecord.copy(
-            treatment = minimalDiagnosisRecord.treatment.copy(
-                systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(systCode1 = null, systSchemanum1 = 1)
+        val records = listOf(
+            minimalDiagnosisRecord.copy(
+                treatment = minimalDiagnosisRecord.treatment.copy(
+                    systemicTreatment = minimalDiagnosisRecord.treatment.systemicTreatment.copy(systCode1 = null, systSchemanum1 = 1)
+                )
             )
-        ))
+        )
         assertThat(filter.hasValidSystemCodes(records)).isFalse()
     }
 }


### PR DESCRIPTION
I have reviewed all of the filters and happy with the results now. 66 tumors are removed:
 - 38 because of inconsistent treatment data (as before)
 - 15 because of non-empty metastatic fields
 - 12 because of invalid pre/post codes
 - 1 because of double tumor data

I believe all of these to be sketchy.

Remains open task for investigation how to deal with tumors where the metastatic discovery was after treatment yet the meta_epis suggests "at start of episode". 